### PR TITLE
Compatibility with Puppet 7.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 Release notes for the Google Cloud KMS hiera-eyaml plugin.
 
 ---------------------------------------------------------
+## 2021-06-03 - 0.1.1
+  * Loosened dependency version requirement on hiera-eyaml for compatibility with Puppet 7.7
 
 ## 2020-11-18 - 0.1.0
   * Updated to support google-cloud-kms 2.0.0

--- a/hiera-eyaml-gkms.gemspec
+++ b/hiera-eyaml-gkms.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency('google-cloud-kms', '2.0.0')
   gem.add_runtime_dependency('google-cloud-kms-v1', '0.3.0')
-  gem.add_runtime_dependency('hiera-eyaml', '3.2.0')
+  gem.add_runtime_dependency('hiera-eyaml', '>= 3.2.0', '< 4.0')
 
   gem.add_development_dependency('rake', '13.0.1')
   gem.add_development_dependency('rubocop', '1.3.1')

--- a/lib/hiera/backend/eyaml/encryptors/gkms/version.rb
+++ b/lib/hiera/backend/eyaml/encryptors/gkms/version.rb
@@ -5,7 +5,7 @@ class Hiera
     module Eyaml
       module Encryptors
         module GkmsVersion
-          VERSION = '0.1.0'
+          VERSION = '0.1.1'
         end
       end
     end


### PR DESCRIPTION
With the release of Puppet 7.7 they seem to have upgraded the hiera-eyaml gem from 3.2.0 to 3.2.1.

I built hiera-eyaml-gkms with that dependency restriction loosened and it seems to work fine with Puppet 7.7 on my Windows and CentOS servers.

Any objections to this change?