### PR TITLE
Support for puppet using gcloud CLI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,12 +70,14 @@ jobs:
                                     --gkms-location="${GCP_LOCATION}" \
                                     --gkms-keyring="${GCP_KEYRING}" \
                                     --gkms-crypto-key="${GCP_CRYPTO_KEY}" \
+                                    --gkms-auth-type="serviceaccount" \
                                     --gkms-credentials=./credentials.json \
                                     -n gkms -o string -s "${GITHUB_SHA}" > ./cipher.txt
           bundle exec eyaml decrypt --gkms-project="${GCP_PROJECT}" \
                                     --gkms-location="${GCP_LOCATION}" \
                                     --gkms-keyring="${GCP_KEYRING}" \
                                     --gkms-crypto-key="${GCP_CRYPTO_KEY}" \
+                                    --gkms-auth-type="serviceaccount" \
                                     --gkms-credentials=./credentials.json \
                                     -n gkms -f ./cipher.txt > ./plain.txt
           echo "Input: ${GITHUB_SHA}"

--- a/lib/hiera/backend/eyaml/encryptors/gkms.rb
+++ b/lib/hiera/backend/eyaml/encryptors/gkms.rb
@@ -107,8 +107,8 @@ class Hiera
 
               decryptor = Encryptor.find 'Gkms'
               ciphertext = decryptor.encode(ciphertext)
-              response = `echo #{ciphertext} | base64 -d | gcloud kms decrypt --location #{location} --keyring #{key_ring} --key #{crypto_key} --project #{project} --plaintext-file - --ciphertext-file -`
-              Base64.decode64(response)
+              resp = `echo #{ciphertext} | base64 -d | gcloud kms decrypt --location #{location} --keyring #{key_ring} --key #{crypto_key} --project #{project} --plaintext-file - --ciphertext-file -`
+              Base64.decode64(resp)
             else
               kms_client.decrypt(name: key_path, ciphertext: ciphertext).plaintext
             end

--- a/lib/hiera/backend/eyaml/encryptors/gkms.rb
+++ b/lib/hiera/backend/eyaml/encryptors/gkms.rb
@@ -4,6 +4,8 @@ require 'hiera/backend/eyaml/encryptor'
 require 'hiera/backend/eyaml/utils'
 require 'hiera/backend/eyaml/options'
 require 'hiera/backend/eyaml/encryptors/gkms/version'
+require 'google/cloud/kms'
+require 'google/cloud/kms/v1'
 
 class Hiera
   module Backend
@@ -39,28 +41,77 @@ class Hiera
             credentials: {
               desc: 'GCP Service Account credentials',
               type: :string
+            },
+            use_gcloud_cli: {
+              desc: 'Use gcloud CLI to encrypt/decrypt secrets',
+              type: :bool,
+              default: false
             }
           }
 
-          def self.encrypt(plaintext)
-            enc_plaintext = Base64.encode64(plaintext)
+          def self.kms_client
+            auth_type = option :auth_type
+
+            if auth_type == 'serviceaccount'
+              credentials = option :credentials
+              raise StandardError, 'gkms_credentials is not defined' unless credentials
+
+              Google::Cloud::Kms.configure do |config|
+                config.credentials = credentials
+                config.timeout = 10.0
+              end
+            else
+              ENV['GOOGLE_AUTH_SUPPRESS_CREDENTIALS_WARNINGS'] = '1'
+            end
+
+            ::Google::Cloud::Kms.key_management_service
+          end
+
+          def self.key_path
             project = option :project
             location = option :location
             key_ring = option :keyring
             crypto_key = option :crypto_key
-            encrypted = `echo "#{enc_plaintext}" | gcloud kms encrypt --location #{location} --keyring #{key_ring} --key #{crypto_key} --project #{project} --plaintext-file - --ciphertext-file -`
+
+            raise StandardError, 'gkms_project is not defined' unless project
+            raise StandardError, 'gkms_keyring is not defined' unless key_ring
+            raise StandardError, 'gkms_crypto_key is not defined' unless crypto_key
+
+            kms_client.crypto_key_path project: project,
+                                       location: location,
+                                       key_ring: key_ring,
+                                       crypto_key: crypto_key
+          end
+
+          def self.encrypt(plaintext)
+            use_gcloud_cli = option :use_gcloud_cli
+            if use_gcloud_cli
+              enc_plaintext = Base64.encode64(plaintext)
+              project = option :project
+              location = option :location
+              key_ring = option :keyring
+              crypto_key = option :crypto_key
+              encrypted = `echo "#{enc_plaintext}" | gcloud kms encrypt --location #{location} --keyring #{key_ring} --key #{crypto_key} --project #{project} --plaintext-file - --ciphertext-file -`
+            else
+              kms_client.encrypt(name: key_path, plaintext: plaintext).ciphertext
+            end
           end
 
           def self.decrypt(ciphertext)
-            project = option :project
-            location = option :location
-            key_ring = option :keyring
-            crypto_key = option :crypto_key
+            use_gcloud_cli = option :use_gcloud_cli
+            if use_gcloud_cli
+              project = option :project
+              location = option :location
+              key_ring = option :keyring
+              crypto_key = option :crypto_key
 
-            decryptor = Encryptor.find "Gkms"
-            ciphertext = decryptor.encode(ciphertext)
-            shell_response = `echo #{ciphertext} | base64 -d | gcloud kms decrypt --location #{location} --keyring #{key_ring} --key #{crypto_key} --project #{project} --plaintext-file - --ciphertext-file -`
-            Base64.decode64(shell_response)
+              decryptor = Encryptor.find 'Gkms'
+              ciphertext = decryptor.encode(ciphertext)
+              shell_response = `echo #{ciphertext} | base64 -d | gcloud kms decrypt --location #{location} --keyring #{key_ring} --key #{crypto_key} --project #{project} --plaintext-file - --ciphertext-file -`
+              Base64.decode64(shell_response)
+            else
+              kms_client.decrypt(name: key_path, ciphertext: ciphertext).plaintext
+            end
           end
         end
       end

--- a/lib/hiera/backend/eyaml/encryptors/gkms.rb
+++ b/lib/hiera/backend/eyaml/encryptors/gkms.rb
@@ -91,7 +91,7 @@ class Hiera
               location = option :location
               key_ring = option :keyring
               crypto_key = option :crypto_key
-              encrypted = `echo "#{enc_plaintext}" | gcloud kms encrypt --location #{location} --keyring #{key_ring} --key #{crypto_key} --project #{project} --plaintext-file - --ciphertext-file -`
+              `echo "#{enc_plaintext}" | gcloud kms encrypt --location #{location} --keyring #{key_ring} --key #{crypto_key} --project #{project} --plaintext-file - --ciphertext-file -`
             else
               kms_client.encrypt(name: key_path, plaintext: plaintext).ciphertext
             end
@@ -107,8 +107,8 @@ class Hiera
 
               decryptor = Encryptor.find 'Gkms'
               ciphertext = decryptor.encode(ciphertext)
-              shell_response = `echo #{ciphertext} | base64 -d | gcloud kms decrypt --location #{location} --keyring #{key_ring} --key #{crypto_key} --project #{project} --plaintext-file - --ciphertext-file -`
-              Base64.decode64(shell_response)
+              response = `echo #{ciphertext} | base64 -d | gcloud kms decrypt --location #{location} --keyring #{key_ring} --key #{crypto_key} --project #{project} --plaintext-file - --ciphertext-file -`
+              Base64.decode64(response)
             else
               kms_client.decrypt(name: key_path, ciphertext: ciphertext).plaintext
             end

--- a/lib/hiera/backend/eyaml/encryptors/gkms/version.rb
+++ b/lib/hiera/backend/eyaml/encryptors/gkms/version.rb
@@ -5,7 +5,7 @@ class Hiera
     module Eyaml
       module Encryptors
         module GkmsVersion
-          VERSION = '0.2.0'
+          VERSION = '0.2.1'
         end
       end
     end


### PR DESCRIPTION
When installing the plugin on puppetserver, it fails on installing `grpc` dependencies on JRuby - here is the similar thread: https://github.com/grpc/grpc/issues/6705

As a workaround, you can use gcloud CLI to communicate with GKMS and encrypt/decrypt values with hiera-eyaml.
The requirement is to have `gcloud` CLI installed and perform authorization.